### PR TITLE
bin/kintsugi: Add version and copyright information.

### DIFF
--- a/bin/kintsugi
+++ b/bin/kintsugi
@@ -8,6 +8,8 @@ require "json"
 require "optparse"
 
 require "kintsugi"
+require_relative "../lib/kintsugi/version"
+
 
 def parse_options!(argv)
   options_parser = create_options_parser
@@ -26,12 +28,18 @@ end
 
 def create_options_parser
   OptionParser.new do |opts|
-    opts.banner = "Usage: kintsugi [pbxproj_filepath] [options]"
+    opts.banner = "Kintsugi, version #{Kintsugi::Version::STRING}\nCopyright (c) 2021 " \
+                  "Lightricks\n\nUsage: kintsugi [pbxproj_filepath] [options]"
     opts.on("--changes-output-path=PATH", "Path to which changes applied to the project are " \
             "written in JSON format. Used for debug purposes.")
 
     opts.on("-h", "--help", "Prints this help") do
       puts opts
+      exit
+    end
+
+    opts.on_tail("-v", "--version", "Prints version") do
+      puts Kintsugi::Version::STRING
       exit
     end
   end

--- a/kintsugi.gemspec
+++ b/kintsugi.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "lib/kintsugi/version"
+
 Gem::Specification.new do |spec|
   spec.name          = "kintsugi"
-  spec.version       = "0.1.0"
+  spec.version       = Kintsugi::Version::STRING
   spec.authors       = ["Ben Yohay"]
   spec.email         = ["ben@lightricks.com"]
   spec.required_ruby_version = ">= 2.5.0"

--- a/lib/kintsugi/version.rb
+++ b/lib/kintsugi/version.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Kintsugi
+  # This module holds the Kintsugi version information.
+  module Version
+    STRING = "0.1.0"
+  end
+end


### PR DESCRIPTION
Helps looks nice:
```
> bin/kintsugi --help
Kintsugi, version 1.0.0
Copyright (c) 2021 Lightricks

Usage: kintsugi [pbxproj_filepath] [options]
        --changes-output-path=PATH   Path to which changes applied to the project are written in JSON format. Used for debug purposes.
    -h, --help                       Prints this help
    -v, --version                    Show version
```

Because argument count check is done without the parser, argument count errors look a tad strange:
```
> bin/kintsugi
Incorrect number of arguments

Kintsugi, version 1.0.0
Copyright (c) 2021 Lightricks

Usage: kintsugi [pbxproj_filepath] [options]
        --changes-output-path=PATH   Path to which changes applied to the project are written in JSON format. Used for debug purposes.
    -h, --help                       Prints this help
    -v, --version                    Show version
```

But it's fine really.