### PR TITLE
Add Xcake and Tuist as alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ See our [Contribution guidelines](./CONTRIBUTING.md).
 
 ## Alternatives
 
-- [XcodeGen](https://github.com/yonaskolb/XcodeGen): You can commit this JSON file into Git instead of the `.pbxproj` file. Then resolving conflicts is much easier.
+All of the alternatives below allow you to generate your Xcode projects based on a spec or manifest. You commit these files to git, and can even remove the `.xcodeproj` files from git.
+
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+- [Tuist](https://github.com/tuist)
+- [Xcake](https://github.com/igor-makarov/xcake)
 
 ## Copyright
 


### PR DESCRIPTION
Hello :)

This little change to the Readme adds two alternatives besides XcodeGen: Xcake (currently maintained by @igor-makarov) and Tuist (disclaimer: I'm a contributor).