### PR TITLE
apply_change_to_project: Fix removal of simple value that's nil already.

### DIFF
--- a/lib/kintsugi/apply_change_to_project.rb
+++ b/lib/kintsugi/apply_change_to_project.rb
@@ -191,14 +191,15 @@ module Kintsugi
         (old_value || {}).reject do |key, value|
           if value != change[key]
             raise "Trying to remove value #{change[key]} of hash with key #{key} but it changed " \
-              "to #{value}."
+              "to #{value}. This is considered a conflict that should be resolved manually."
           end
 
           change.key?(key)
         end
       when String
-        if old_value != change
-          raise "Value changed from #{old_value} to #{change}."
+        if old_value != change && !old_value.nil?
+          raise "Trying to remove value #{change}, but the existing value is #{old_value}. This " \
+            "is considered a conflict that should be resolved manually."
         end
 
         nil

--- a/spec/kintsugi_apply_change_to_project_spec.rb
+++ b/spec/kintsugi_apply_change_to_project_spec.rb
@@ -770,6 +770,25 @@ describe Kintsugi, :apply_change_to_project do
     expect(base_project).to be_equivalent_to_project(theirs_project)
   end
 
+  it "removes attribute target changes from a project it was removed from already" do
+    base_project.root_object.attributes["TargetAttributes"] =
+      {"foo" => {"LastSwiftMigration" => "1140"}}
+    base_project.save
+
+    theirs_project = create_copy_of_project(base_project.path, "theirs")
+    theirs_project.root_object.attributes["TargetAttributes"]["foo"] = {}
+
+    ours_project = create_copy_of_project(base_project.path, "ours")
+    ours_project.root_object.attributes["TargetAttributes"]["foo"] = {}
+
+    changes_to_apply = get_diff(theirs_project, base_project)
+
+    described_class.apply_change_to_project(ours_project, changes_to_apply)
+    ours_project.save
+
+    expect(ours_project).to be_equivalent_to_project(theirs_project)
+  end
+
   it "identifies subproject added in separate times" do
     framework_filename = "baz"
 


### PR DESCRIPTION
If the applied change removed a value and the existing value is
different from the removed value, it is considered a conflict.
However, this is not true in the case the existing value was already
removed.

In addition, improve messages in case of real conflicts when dealing
with removal of simple attributes.
