### PR TITLE
apply_change_to_project: Fix when old and new values types don't match.

### DIFF
--- a/lib/kintsugi/apply_change_to_project.rb
+++ b/lib/kintsugi/apply_change_to_project.rb
@@ -186,6 +186,9 @@ module Kintsugi
     def apply_removal_to_simple_attribute(old_value, removed_change, added_change)
       case removed_change
       when Array
+        if old_value.is_a?(String)
+          old_value = [old_value]
+        end
         (old_value || []) - removed_change
       when Hash
         (old_value || {}).reject do |key, value|
@@ -214,6 +217,9 @@ module Kintsugi
     def apply_addition_to_simple_attribute(old_value, change)
       case change
       when Array
+        if old_value.is_a?(String)
+          old_value = [old_value]
+        end
         (old_value || []) + change
       when Hash
         old_value ||= {}


### PR DESCRIPTION
When adding or removing simple values, until now there was an assumption
that the old value and new value have the same type. This is not
necessarily the case, for example a build setting can be an array with
multiple values, but it can also be a string if it has only a single
value.
