### PR TITLE
spec_helper: Support "fit" focused tests.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be


### PR DESCRIPTION
One feature enables marking focused tests with "fit", while the other
runs all the tests if there are no focused tests.
