### PR TITLE
kintsugi: Fix error codes on exceptions.

### DIFF
--- a/bin/kintsugi
+++ b/bin/kintsugi
@@ -34,6 +34,8 @@ begin
   command.action.call(options, ARGV)
 rescue ArgumentError => e
   puts "#{e.class}: #{e}"
+  exit(1)
 rescue Kintsugi::MergeError => e
   puts e
+  exit(1)
 end


### PR DESCRIPTION
Previously when ArgumentError or MergeError occurred the exit code of
the program was 0 because `exit` wasn't invoked explicitly.
