### PR TITLE
cli: fix incorrect git attributes file name.

### DIFF
--- a/lib/kintsugi/cli.rb
+++ b/lib/kintsugi/cli.rb
@@ -109,7 +109,7 @@ module Kintsugi
     def global_attributes_file_path
       # The logic to decide the path to the global attributes file is described at:
       # https://git-scm.com/docs/gitattributes.
-      config_attributes_file_path = `git config --global core.attributesfile`
+      config_attributes_file_path = `git config --global core.attributesfile`.chomp
       return config_attributes_file_path unless config_attributes_file_path.empty?
 
       if ENV["XDG_CONFIG_HOME"].nil? || ENV["XDG_CONFIG_HOME"].empty?


### PR DESCRIPTION
When `install-driver` ran, The git attributes file path was
retrieved by running `git config --global core.attributesfile`,
Since this command ends with `\n`, in cases where it was configured
the file path got `\n` added to it.

Chomping the configured git attributes file path resolved this issue.