### PR TITLE
tests.yml: Use latest rubygems version.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5.8
+          rubygems: latest
           bundler-cache: true
 
       - name: Run Rake


### PR DESCRIPTION
A warning is emitted when installing bundle:
`Your RubyGems version (2.7.6.2) has a bug that prevents
`required_ruby_version` from working for Bundler`.

Updating to the latest rubygems version should solve this issue.
