### PR TITLE
apply change: Fix adding component with non default simple attributes.

### DIFF
--- a/lib/kintsugi/apply_change_to_project.rb
+++ b/lib/kintsugi/apply_change_to_project.rb
@@ -676,7 +676,11 @@ module Kintsugi
 
         attribute_name = attribute_name_from_change_name(change_name)
         if simple_attribute?(component, attribute_name)
-          apply_change_to_simple_attribute(component, attribute_name, {added: change_value})
+          simple_attribute_change = {
+            added: change_value,
+            removed: simple_attribute_default_value(component, attribute_name)
+          }
+          apply_change_to_simple_attribute(component, attribute_name, simple_attribute_change)
           next
         end
 
@@ -692,6 +696,12 @@ module Kintsugi
             "to object #{component}. Attribute name is '#{change_name}'"
         end
       end
+    end
+
+    def simple_attribute_default_value(component, attribute_name)
+      component.simple_attributes.find do |attribute|
+        attribute.name == attribute_name
+      end.default_value
     end
 
     def find_file(project, file_reference_change, file_filter: ->(_) { true })

--- a/spec/kintsugi_apply_change_to_project_spec.rb
+++ b/spec/kintsugi_apply_change_to_project_spec.rb
@@ -1062,6 +1062,20 @@ describe Kintsugi, :apply_change_to_project do
       expect(base_project).to be_equivalent_to_project(theirs_project)
     end
 
+    it "adds build phase with a simple attribute value that has non nil default" do
+      theirs_project = create_copy_of_project(base_project.path, "theirs")
+
+      theirs_project.targets[0].new_shell_script_build_phase("bar")
+      theirs_project.targets[0].build_phases.last.shell_script = "Other value"
+
+      changes_to_apply = get_diff(theirs_project, base_project)
+
+      described_class.apply_change_to_project(base_project, changes_to_apply)
+      base_project.save
+
+      expect(base_project).to be_equivalent_to_project(theirs_project)
+    end
+
     it "removes build phase" do
       base_project.targets[0].new_shell_script_build_phase("bar")
 


### PR DESCRIPTION
When adding a component with simple attributes, these attributes might
have default values that aren't `nil`. Previously, when such a thing
occurred it would result in a `MergeError`, because the removed change
was assumed to be `nil` since the component was just added, but in
practice it would be set to the default value.
The solution is to set the removed change value to the default value.
