### PR TITLE
apply_change_to_project: Ignore when diff is nil or without root object.

### DIFF
--- a/lib/kintsugi/apply_change_to_project.rb
+++ b/lib/kintsugi/apply_change_to_project.rb
@@ -35,6 +35,8 @@ module Kintsugi
     #
     # @return [void]
     def apply_change_to_project(project, change)
+      return unless change&.key?("rootObject")
+
       # We iterate over the main group and project references first because they might create file
       # or project references that are referenced in other parts.
       unless change["rootObject"]["mainGroup"].nil?

--- a/spec/kintsugi_apply_change_to_project_spec.rb
+++ b/spec/kintsugi_apply_change_to_project_spec.rb
@@ -27,6 +27,13 @@ describe Kintsugi, :apply_change_to_project do
     end
   end
 
+  it "not raises when change is nil or doesn't have root object" do
+    expect {
+      described_class.apply_change_to_project(base_project, nil)
+      described_class.apply_change_to_project(base_project, {})
+    }.not_to raise_error
+  end
+
   it "adds new target" do
     theirs_project = create_copy_of_project(base_project.path, "theirs")
     theirs_project.new_target("com.apple.product-type.library.static", "foo", :ios)


### PR DESCRIPTION
Until now it was assumed that `change` variable was always non nil and
containing the `rootObject` key. If that's not the case simply apply no
changes.
