### PR TITLE
Kintsugi: Fix crash when a build file without file reference exists.

### DIFF
--- a/lib/kintsugi/apply_change_to_project.rb
+++ b/lib/kintsugi/apply_change_to_project.rb
@@ -687,7 +687,7 @@ module Kintsugi
       end
 
       existing_build_file = build_phase.files.find do |build_file|
-        build_file.file_ref.path == change["fileRef"]["path"]
+        build_file.file_ref && build_file.file_ref.path == change["fileRef"]["path"]
       end
       return if !Settings.allow_duplicates && !existing_build_file.nil?
 

--- a/spec/kintsugi_apply_change_to_project_spec.rb
+++ b/spec/kintsugi_apply_change_to_project_spec.rb
@@ -595,6 +595,22 @@ describe Kintsugi, :apply_change_to_project do
       expect(base_project).to be_equivalent_to_project(theirs_project, ignore_keys: ["containerPortal"])
     end
 
+    it "adds build when there is a build file without file ref" do
+      target = base_project.new_target("com.apple.product-type.library.static", "foo", :ios)
+      target.frameworks_build_phase.add_file_reference(nil)
+      base_project.save
+
+      theirs_project = create_copy_of_project(base_project.path, "theirs")
+      file_reference = theirs_project.main_group.new_reference("bar")
+      theirs_project.targets[0].frameworks_build_phase.add_file_reference(file_reference)
+
+      changes_to_apply = get_diff(theirs_project, base_project)
+      other_project = create_copy_of_project(base_project.path, "theirs")
+      described_class.apply_change_to_project(other_project, changes_to_apply)
+
+      expect(other_project).to be_equivalent_to_project(theirs_project)
+    end
+
     it "adds product ref to build file" do
       base_project.main_group.new_reference("bar")
       base_project.save


### PR DESCRIPTION
The code assumed that a `file_ref` of a build file always existed and
it accessed its `path` property which would cause a crash.
