### PR TITLE
kintsugi.gemspec: bump xcodeproj for Xcode 15

### DIFF
--- a/kintsugi.gemspec
+++ b/kintsugi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "tty-prompt", "~> 0"
-  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.22.0"
+  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.23.0"
 
   spec.add_development_dependency "git", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
CocoaPods 1.13.0 includes `Xcode 15 fix` that is required for Xcode 15 to avoid build errors.
https://github.com/CocoaPods/CocoaPods/releases/tag/1.13.0

It depends on xcodeproj 1.23.0.