### PR TITLE
xcodeproj_extensions: fix wrong serialization with swift package target.

### DIFF
--- a/lib/kintsugi/xcodeproj_extensions.rb
+++ b/lib/kintsugi/xcodeproj_extensions.rb
@@ -125,6 +125,17 @@ module Xcodeproj
           hash
         end
       end
+
+      # By default, for this type, the `display_name` is used when calling `ascii_plist_annotation` (which is used
+      # to serialize the project to disk). In the case where the `display_name` contains a "plugin:" prefix, which
+      # means that the package is a plugin, the prefix is ommitted so just the package name is used.
+      # This, of course can be implemented in a better way, like adding a field to this object as plugin, marking it
+      # as a plugin, but this is a very simple way to achieve the desired result.
+      class XCSwiftPackageProductDependency
+        def ascii_plist_annotation
+          " #{display_name.delete_prefix("plugin:")} "
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We have a build plugin which is a Swift package, it's represented as a
`XCSwiftPackageProductDependency` object. The display name contains a "plugin:"
prefix so when it's serialized it's everywhere. The problem is that Xcode
removes this prefix and uses the package name in the keys of the serialized
objects and in refs to them (in the comments).

Below is an example before and after the change.

before (wrong):
```
/* Begin XCSwiftPackageProductDependency section */
		19AA76E52A9F557900F1F6A1 /* plugin:SomePackageName */ = {
			isa = XCSwiftPackageProductDependency;
			productName = "plugin:SomePackageName";
		};
```
after (correct):
```
/* Begin XCSwiftPackageProductDependency section */
		19AA76E52A9F557900F1F6A1 /* SomePackageName */ = {
			isa = XCSwiftPackageProductDependency;
			productName = "plugin:SomePackageName";
		};
```