### PR TITLE
CI: test on multiple ruby versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ jobs:
   main-job:
     name: Main
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [2.6, 2.7, 3.2, 3.3]
 
     steps:
       - name: Checkout repo
@@ -18,8 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.10
-          rubygems: latest
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Run Rake


### PR DESCRIPTION
Currently, the tests were running on ruby 2.6 and using latest
RubyGems. This is broken since latest RubyGems support Ruby>3. This is
fine since ruby 2.7 is now deprecated.

Kintsugi runs usually on macOS which comes built-in with ruby 2.6, so
it's worth keep testing on that version. So this commit add tests on
multiple ruby versions.
