### PR TITLE
Release: use head ruby version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.10
+          ruby-version: head
           rubygems: latest
 
       - name: Draft a new release


### PR DESCRIPTION
Previously, ruby 2.6 with latest rubygems was used to publish them gem.
Latest rubygems doesn't support ruby 2.6 anymore and all is needed to
upload is latest rubygems, so this is used.
