### PR TITLE
kintsugi.gemspec: bump xcodeproj

### DIFF
--- a/kintsugi.gemspec
+++ b/kintsugi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "tty-prompt", "~> 0"
-  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.23.0"
+  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.24.0"
 
   spec.add_development_dependency "git", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
The xcodeproj gem 1.24.0 includes a fix issues including one fixing SPM package annotation and causing unwanted after a conflict resolution