### PR TITLE
xcodeproj_extensions: fix wrong serialization with local swift packages.

### DIFF
--- a/lib/kintsugi/xcodeproj_extensions.rb
+++ b/lib/kintsugi/xcodeproj_extensions.rb
@@ -136,6 +136,16 @@ module Xcodeproj
           " #{display_name.delete_prefix("plugin:")} "
         end
       end
+
+      # The original implementation is  `" #{isa} \"#{File.basename(display_name)}\"` so that means that if we have a
+      # relative path which is Path/To/Package, the item will be serialized as `XCLocalSwiftPackageReference "Package"`.
+      # And Xcode will automatically fix this to be `XCLocalSwiftPackageReference "Path/To/Package"`.
+      # So, we need to patch the implementation and make sure the whole path is used.
+      class XCLocalSwiftPackageReference
+        def ascii_plist_annotation
+          " #{isa} \"#{display_name}\" "
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In case of a local Swift package, xcodeproj wrongfully uses the
`File.basename` of the path and Xcode fixes that to be the full path.
This commit patches the xcodeproj implementation and fixes it.

Below is an example before and after the change.

before (wrong):
```
/* Begin XCLocalSwiftPackageReference section */
                BA78EB3B2C889B20000D85B2 /* XCLocalSwiftPackageReference "Package" */ = {
                        isa = XCLocalSwiftPackageReference;
                        relativePath = ../Path/To/Package;
                };
```

after (correct)
```
/* Begin XCLocalSwiftPackageReference section */
                BA78EB3B2C889B20000D85B2 /* XCLocalSwiftPackageReference "../Path/To/Package" */ = {
                        isa = XCLocalSwiftPackageReference;
                        relativePath = ../Path/To/Package;
                };
```