### PR TITLE
Bump Xcodeproj to 1.25.0

### DIFF
--- a/kintsugi.gemspec
+++ b/kintsugi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "tty-prompt", "~> 0"
-  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.24.0"
+  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.25.0"
 
   spec.add_development_dependency "git", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Bump Xcodeproj version requirements to allow version `1.25.0`

[Older versions contain a dependency with a known security vulnerability, which is flagged by GitHub.](https://www.ruby-lang.org/en/news/2024/08/22/dos-rexml-cve-2024-43398/)