### PR TITLE
Bump Xcodeproj to 1.27.0

### DIFF
--- a/kintsugi.gemspec
+++ b/kintsugi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "tty-prompt", "~> 0"
-  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.25.0"
+  spec.add_dependency "xcodeproj", ">= 1.19.0", "<= 1.27.0"
 
   spec.add_development_dependency "git", "~> 1.11"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
## The Fix
Bump Xcodeproj version requirements to allow version 1.27.0

The latest version of cocoapods, `1.16.2` now requires at minimum 1.27.0 of `xcodeproj`
See these [release notes](https://github.com/CocoaPods/CocoaPods/releases)

This PR bumps Xcodeproj to restore compatibility between the latest versions of Kintsugi and Cocoapods.

I've verified that running `bundle install` within my project whose Gemfile depends on `kintsugi` now works. However I haven't tested the functionality of `kintsugi` for compatibility with `xcodeproj` 1.27.0 as I'm not sure what to test for.

I hope this is helpful, in any case.

## The Bug

Before this PR, running `bundle install` within my project root results in this error

```
Fetching https://github.com/pbsupplyco/Kintsugi.git
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Could not find compatible versions

Because every version of kintsugi depends on xcodeproj >= 1.19.0, <= 1.25.0
  and cocoapods >= 1.16.2 depends on xcodeproj >= 1.27.0, < 2.0,
  every version of kintsugi is incompatible with cocoapods >= 1.16.2.
So, because Gemfile depends on cocoapods = 1.16.2
  and Gemfile depends on kintsugi >= 0,
  version solving has failed.
```

FYI before this fix, my Gemfile had
```
source 'https://rubygems.org'

ruby '~> 3.2.1'

gem 'activesupport', '= 7.0.8'
gem 'cocoapods', '= 1.16.2'
gem 'fastlane', '~> 2.225.0'
gem 'kintsugi', require: false
```

Once I updated `kintsugi` to run off the feature branch I'm merging in, it worked fine.